### PR TITLE
Release jobs which cause exceptions back to the queue

### DIFF
--- a/src/Handler/Laravel/Job.php
+++ b/src/Handler/Laravel/Job.php
@@ -59,7 +59,11 @@ class Job
             $this->transport = new $data['transport']['class']($data['transport']['options']);
         }
 
-        $this->transport->send($data['url'], $data['data'], $data['headers']);
-        $job->delete();
+        try {
+            $this->transport->send($data['url'], $data['data'], $data['headers']);
+            $job->delete();
+        } catch (\Exception $e) {
+            $job->release(30);
+        }
     }
 }


### PR DESCRIPTION
From @pulkitjalan's patch 5ae35aec11051dbe8dd2a02489c8c39bd0eee0c2

If an exception is encountered while working on a queued job to submit an error to Sentry, this exception would be caught and added to the queue as another job. This can snowball and cause all sorts of problems; see #14.

Instead, catch any exception thrown when trying to submit an error and ignore it, instead releasing the original error submission job back to the queue after a delay.

Note that this does not protect against similar issues when synchronously submitting error reports.

This fixes #14 and possibly #16.
